### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -14,7 +14,7 @@ source /usr/share/yunohost/helpers
 
 secret=$(ynh_string_random --length=50)
 email=$(ynh_user_get_info --username=$admin --key=mail)
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 firstname=$(yunohost user list --fields firstname --output-as json | jq -r .users.$admin.firstname)
 lastname=$(yunohost user list --fields lastname --output-as json | jq -r .users.$admin.lastname)
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -9,7 +9,7 @@ source /usr/share/yunohost/helpers
 
 secret=$(ynh_string_random --length=50)
 email=$(ynh_user_get_info --username=$admin --key=mail)
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 
 #=================================================
 # STOP SYSTEMD SERVICE


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.