### PR TITLE
Fix demo and doc links

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -14,8 +14,8 @@ maintainers = []
 [upstream]
 license = "AGPL-3.0"
 website = "https://planka.app/"
-demo = "https://plankanban.github.io/planka/#/"
-admindoc = "https://docs.planka.cloud/docs/intro/"
+demo = "https://community.demo.planka.cloud/login#emailOrUsername=pm1%40demo.com&password=DemoPass123!"
+admindoc = "https://docs.planka.cloud/docs/welcome"
 code = "https://github.com/plankanban/planka"
 
 [integration]


### PR DESCRIPTION
## Problem

- *Links to the official demo and documentation for administrators were no longer up to date.*

## Solution

- *Update Links*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
