### PR TITLE
2.1.1

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Planka"
 description.en = "Realtime kanban board for workgroups"
 description.fr = "Tableau Kanban en temps réel pour les groupes de travail"
 
-version = "2.1.0~ynh1"
+version = "2.1.1~ynh1"
 
 maintainers = []
 
@@ -50,11 +50,11 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/plankanban/planka/releases/download/v2.1.0/planka-prebuild.zip"
-    sha256 = "72c643ef83862f54490dc886d45c89aa5ff5e05d44bd5b87bb7cff4c121c58b3"
+    url = "https://github.com/plankanban/planka/releases/download/2.1.1/planka-prebuild.zip"
+    sha256 = "2c87f82436261aae47e3e9ee62f4b6a1c517eefd6e81a5bf6ad2c514a183e398"
     autoupdate.strategy = "latest_github_release"
     autoupdate.asset = "^planka-prebuild.zip$"
-    autoupdate.version_regex = "v(\\d+\\.\\d+\\.\\d+)"
+    autoupdate.version_regex = "(\\d+\\.\\d+\\.\\d+)"
 
     [resources.system_user]
     allow_email = true


### PR DESCRIPTION
## Problem

- *The automatic update did not work (v2.1.0 > 2.1.1)*

## Solution

- *Fix the regex of the automatic update (remove the v before the version number)*
- *Manual update of the manifest*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
